### PR TITLE
Changes to make rappel work

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+rm src/pometo_lexer.erl
+rm src/pometo_parser.erl
 rebar3 compile && erl -pa _build/default/lib/pometo/ebin/ -s runner run

--- a/src/parser_include.hrl
+++ b/src/parser_include.hrl
@@ -6,10 +6,14 @@ append_scalar(#'¯¯⍴¯¯'{dimensions = [D1], vals = V1, type = Type},
   % ?debugFmt("Rho1 is ~p~nRho2 is ~p~n", [Rho1, Rho2]),
   #'¯¯⍴¯¯'{dimensions = [D1 + D2], vals = V1 ++ V2, type = Type}.
 
-tag_scalar(Type, {_, _, _, _, Val}) ->
+tag_scalar(Type, positive, {_, _, _, _, Val}) ->
   #'¯¯⍴¯¯'{dimensions = [1],
            type = Type,
-           vals = [Val]}.
+           vals = [Val]};
+tag_scalar(Type, negative, {_, _, _, _, Val}) ->
+  #'¯¯⍴¯¯'{dimensions = [1],
+           type = Type,
+           vals = [-Val]}.
 
 extract(Application, {scalar_fn, _, _, _, Fnname}, Args) ->
 	#expr{type        = scalar,

--- a/src/parser_records.hrl
+++ b/src/parser_records.hrl
@@ -1,7 +1,7 @@
 -record('¯¯⍴¯¯', {
                   style      = eager, % [eager | lazy]
                   indexed    = false,
-                  type,               % scalar_fn
+                  type,               % int | float
                   dimensions = [],
                   vals       = []
                  }).

--- a/src/pometo_lexer.xrl
+++ b/src/pometo_lexer.xrl
@@ -28,6 +28,8 @@ Rules.
 {BOOL}     : {token, {bool,  TokenLine, TokenChars, string:to_upper(TokenChars) == "TRUE"}}.
 {VARIABLE} : {token, {var,   TokenLine, TokenChars, TokenChars}}.
 
+¯ : {token, {unary_negate, TokenLine, TokenChars, "¯"}}.
+
 \+ : {token, {scalar_fn, TokenLine, TokenChars, "+"}}.
 -  : {token, {scalar_fn, TokenLine, TokenChars, "-"}}.
 ×  : {token, {scalar_fn, TokenLine, TokenChars, "×"}}.

--- a/src/pometo_parser.yrl
+++ b/src/pometo_parser.yrl
@@ -9,11 +9,12 @@ Let
 
 Terminals
 
-int
-float
 scalar_fn
 let_op
 var
+int
+float
+unary_negate
 
 .
 
@@ -29,8 +30,11 @@ Let -> var let_op Vector : make_let('$1', '$3').
 Vector -> Vector Scalar : append_scalar('$1', '$2').
 Vector -> Scalar        : '$1'.
 
-Scalar -> int   : tag_scalar(int,   '$1').
-Scalar -> float : tag_scalar(float, '$1').
+Scalar -> unary_negate int   : tag_scalar(int,   negative, '$2').
+Scalar -> unary_negate float : tag_scalar(float, negative, '$2').
+
+Scalar -> int                : tag_scalar(int,   positive, '$1').
+Scalar -> float              : tag_scalar(float, positive, '$1').
 
 Erlang code.
 

--- a/src/pometo_runtime.erl
+++ b/src/pometo_runtime.erl
@@ -47,7 +47,7 @@ run_ast(#expr{type        = scalar,
 			                 #'¯¯⍴¯¯'{dimensions = D, vals = V}
 			                ]}, Bindings) ->
 	Shape =#'¯¯⍴¯¯'{dimensions = D, vals = [execute_monadic(Fn, X) || X <- V]},
-	{Shape, Bindings};
+	{Shape, Bindings}.
 
 zip([], [], _, Acc) -> lists:reverse(Acc);
 zip([H1 | T1], [H2 | T2], Fn, Acc) ->

--- a/src/pometo_runtime.erl
+++ b/src/pometo_runtime.erl
@@ -12,31 +12,34 @@
 -define(SPACE, 32).
 
 
-run_ast(#let_op{vals = Vals}, []) -> Vals;
+run_ast(#let_op{vals = Vals} = Binding, Bindings) -> {Vals, [Binding | Bindings]};
 run_ast(#expr{type        = scalar,
 			  application = dyadic,
 	          fn_name     = Fn,
 			  args        = [
 			  			     #'¯¯⍴¯¯'{dimensions = D, vals = V1},
 			                 #'¯¯⍴¯¯'{dimensions = D, vals = V2}
-			                ]}, _Dict) ->
-	#'¯¯⍴¯¯'{dimensions = D, vals = zip(V1, V2, Fn, ?EMPTY_ACCUMULATOR)};
+			                ]}, Bindings) ->
+	Shape = #'¯¯⍴¯¯'{dimensions = D, vals = zip(V1, V2, Fn, ?EMPTY_ACCUMULATOR)},
+	{Shape, Bindings};
 run_ast(#expr{type        = scalar,
 			  application = dyadic,
 	          fn_name     = Fn,
 			  args        = [
 			  			     #'¯¯⍴¯¯'{dimensions = [1], vals = [V1]},
 			                 #'¯¯⍴¯¯'{dimensions = D,   vals = V2}
-			                ]}, _Dict) ->
-	#'¯¯⍴¯¯'{dimensions = D, vals = apply(V2, V1, left, Fn, ?EMPTY_ACCUMULATOR)};
+			                ]}, Bindings) ->
+	Shape = #'¯¯⍴¯¯'{dimensions = D, vals = apply(V2, V1, left, Fn, ?EMPTY_ACCUMULATOR)},
+	{Shape, Bindings};
 run_ast(#expr{type        = scalar,
 			  application = dyadic,
 	          fn_name     = Fn,
 			  args        = [
 			  			     #'¯¯⍴¯¯'{dimensions = D,   vals = V1},
 			                 #'¯¯⍴¯¯'{dimensions = [1], vals = [V2]}
-			                ]}, _Dict) ->
-	#'¯¯⍴¯¯'{dimensions = D, vals = apply(V1, V2, right, Fn, ?EMPTY_ACCUMULATOR)}.
+			                ]}, Bindings) ->
+	Shape = #'¯¯⍴¯¯'{dimensions = D, vals = apply(V1, V2, right, Fn, ?EMPTY_ACCUMULATOR)},
+	{Shape, Bindings}.
 % run_ast(#expr{type        = scalar,
 %			  application = monadic,
 %	          fn_name     = Fn,
@@ -75,4 +78,7 @@ rho(List) when is_list(List) ->
 	         vals       = List}.
 
 format(	#'¯¯⍴¯¯'{vals = V}) ->
-	string:join([io_lib:format("~p", [X]) || X <- V], [" "]).
+	string:join([fmt(X) || X <- V], [" "]).
+
+fmt(X) when X < 0 -> io_lib:format("¯~p", [abs(X)]);
+fmt(X)            -> io_lib:format("~p",  [X]).

--- a/src/runner.erl
+++ b/src/runner.erl
@@ -1,3 +1,5 @@
+%% coding: UTF-8\n
+
 -module(runner).
 
 -export([
@@ -6,7 +8,9 @@
 
 run() ->
 	Codes = [
-	         "A ← 1 2 3"
+	         "Z🤣🤣😀😃😄😁😆😂😅🐜+K😑[&^😐¯P😍÷I😍×E😍😍😍😍 ← 1 2 3"
+%	         "Z😍 ← 1 2 3"
+%			 "KORYTNAČKA ← 1 2 3"
 	         ],
 	[run(X) || X <- Codes],
 	exit(1).

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-rebar3 pometo_docs_to_tests && rebar3 eunit
+rm -rf _build/default/plugins/pometo_docs_to_tests && rebar3 pometo_docs_to_tests && rebar3 eunit


### PR DESCRIPTION
Includes bug fixes for tests with negative numbers that were failing.

The features included here are:

* separation of statements and bindings
* creation of ¯ as a unitary negation operator (in addition to it being a printed sign of a negative number)