### PR TITLE
New AST structure 'Liffey'

### DIFF
--- a/src/parser_records.hrl
+++ b/src/parser_records.hrl
@@ -1,21 +1,20 @@
+%% basic AST record
+-record(liffey, {
+                 op,
+                 args = []
+                }).
+
+%% special operator record
 -record('¯¯⍴¯¯', {
                   style      = eager, % [eager | lazy]
                   indexed    = false,
-                  type,               % int | float
-                  dimensions = [],
-                  vals       = []
+                  dimensions = []
                  }).
 
--record(expr, {
-    type,
-    expression,
-    application,      % [monadic | dyadic]
-    fn_name,
-    args         = []
-  }).
+% leaf records
+-record(var, {
+              name,
+              expr
+             }).
 
--record(let_op, {
-     var,
-     expression,
-     vals
-  }).
+% complex number record TBD

--- a/src/pometo_parser.yrl
+++ b/src/pometo_parser.yrl
@@ -4,6 +4,7 @@ Expression
 Vector
 Scalar
 Let
+Value
 
 .
 
@@ -27,14 +28,14 @@ Expression -> scalar_fn Vector        : extract(monadic, '$1', ['$2']).
 
 Let -> var let_op Vector : make_let('$1', '$3').
 
-Vector -> Vector Scalar : append_scalar('$1', '$2').
+Vector -> Vector Scalar : append('$1', '$2').
 Vector -> Scalar        : '$1'.
 
-Scalar -> unary_negate int   : tag_scalar(int,   negative, '$2').
-Scalar -> unary_negate float : tag_scalar(float, negative, '$2').
+Scalar -> unary_negate Value  : handle_value(negative, '$2').
+Scalar -> Value               : handle_value(positive, '$1').
 
-Scalar -> int                : tag_scalar(int,   positive, '$1').
-Scalar -> float              : tag_scalar(float, positive, '$1').
+Value -> int   : '$1'.
+Value -> float : '$1'.
 
 Erlang code.
 

--- a/src/pometo_runtime.erl
+++ b/src/pometo_runtime.erl
@@ -4,50 +4,43 @@
 
 -export([
 		  rho/1,
-		  run_ast/2,
+		  run_ast/1,
 		  format/1
 		]).
 
 -define(EMPTY_ACCUMULATOR, []).
 -define(SPACE, 32).
 
+run_ast({#liffey{op = #'¯¯⍴¯¯'{}} = L, Bindings}) ->
+	{L, Bindings};
+run_ast({#liffey{op = {dyadic, Op}, args = [A1, A2]}, Bindings}) ->
+	dyadic(Op, A1, A2, Bindings);
+run_ast({#liffey{op = {monadic, Op}, args = [A]}, Bindings}) ->
+	monadic(Op, A, Bindings).
 
-run_ast(#let_op{vals = Vals} = Binding, Bindings) -> {Vals, [Binding | Bindings]};
-run_ast(#expr{type        = scalar,
-			  application = dyadic,
-	          fn_name     = Fn,
-			  args        = [
-			  			     #'¯¯⍴¯¯'{dimensions = D, vals = V1},
-			                 #'¯¯⍴¯¯'{dimensions = D, vals = V2}
-			                ]}, Bindings) ->
-	Shape = #'¯¯⍴¯¯'{dimensions = D, vals = zip(V1, V2, Fn, ?EMPTY_ACCUMULATOR)},
-	{Shape, Bindings};
-run_ast(#expr{type        = scalar,
-			  application = dyadic,
-	          fn_name     = Fn,
-			  args        = [
-			  			     #'¯¯⍴¯¯'{dimensions = [1], vals = [V1]},
-			                 #'¯¯⍴¯¯'{dimensions = D,   vals = V2}
-			                ]}, Bindings) ->
-	Shape = #'¯¯⍴¯¯'{dimensions = D, vals = apply(V2, V1, left, Fn, ?EMPTY_ACCUMULATOR)},
-	{Shape, Bindings};
-run_ast(#expr{type        = scalar,
-			  application = dyadic,
-	          fn_name     = Fn,
-			  args        = [
-			  			     #'¯¯⍴¯¯'{dimensions = D,   vals = V1},
-			                 #'¯¯⍴¯¯'{dimensions = [1], vals = [V2]}
-			                ]}, Bindings) ->
-	Shape = #'¯¯⍴¯¯'{dimensions = D, vals = apply(V1, V2, right, Fn, ?EMPTY_ACCUMULATOR)},
-	{Shape, Bindings};
-run_ast(#expr{type        = scalar,
-			  application = monadic,
-	          fn_name     = Fn,
-			  args        = [
-			                 #'¯¯⍴¯¯'{dimensions = D, vals = V}
-			                ]}, Bindings) ->
-	Shape =#'¯¯⍴¯¯'{dimensions = D, vals = [execute_monadic(Fn, X) || X <- V]},
-	{Shape, Bindings}.
+rho(List) when is_list(List) ->
+	Len = length(List),
+	#'¯¯⍴¯¯'{style      = eager,
+	         indexed    = false,
+	         dimensions = [Len]}.
+
+dyadic(Op, #liffey{op = #'¯¯⍴¯¯'{dimensions = N}, args = A1} = L1,
+	       #liffey{op = #'¯¯⍴¯¯'{dimensions = N}, args = A2}, Bindings) ->
+		Vals = zip(A1, A2, Op, ?EMPTY_ACCUMULATOR),
+		{L1#liffey{args = Vals}, Bindings};
+dyadic(Op, #liffey{op = #'¯¯⍴¯¯'{dimensions = [1]}, args = [A1]},
+	       #liffey{                                 args = A2} = L2, Bindings) ->
+		% order of A2 and A1 swapped and return record based on 2nd rho
+		Vals = apply(A2, A1, left, Op, ?EMPTY_ACCUMULATOR),
+		{L2#liffey{args = Vals}, Bindings};
+dyadic(Op, #liffey{                                 args = A1} = L1,
+	       #liffey{op = #'¯¯⍴¯¯'{dimensions = [1]}, args = [A2]}, Bindings) ->
+		Vals = apply(A1, A2, right, Op, ?EMPTY_ACCUMULATOR),
+		{L1#liffey{args = Vals}, Bindings}.
+
+monadic(Op, #liffey{args = A} = L, Bindings) ->
+	NewA = [execute_monadic(Op, X) || X <- A],
+	{L#liffey{args = NewA}, Bindings}.
 
 zip([], [], _, Acc) -> lists:reverse(Acc);
 zip([H1 | T1], [H2 | T2], Fn, Acc) ->
@@ -61,7 +54,6 @@ apply([H | T], V, left, Fn, Acc) ->
 apply([H | T], V, right, Fn, Acc) ->
 	NewAcc = execute_dyadic(Fn, H, V),
 	apply(T, V, right, Fn, [NewAcc | Acc]).
-
 
 execute_dyadic("+", L, R) -> L + R;
 execute_dyadic("-", L, R) -> L - R;
@@ -80,17 +72,8 @@ signum(V) when V == 0 ->
 signum(V) when V > 0 ->
     1.
 
-rho(List) when is_list(List) ->
-	Len = length(List),
-	#'¯¯⍴¯¯'{style      = eager,
-	         indexed    = false,
-	         dimensions = [Len],
-	         vals       = List}.
-
-format(#'¯¯⍴¯¯'{vals = V}) ->
-	string:join([fmt(X) || X <- V], [" "]).
-
-% get_variable(#let_op{var = V}) -> V.
+format(#liffey{op = #'¯¯⍴¯¯'{}, args = Args}) ->
+	lists:flatten(string:join([fmt(X) || X <- Args], [" "])).
 
 fmt(X) when X < 0 -> io_lib:format("¯~p", [abs(X)]);
 fmt(X)            -> io_lib:format("~p",  [X]).

--- a/src/pometo_test_helper.erl
+++ b/src/pometo_test_helper.erl
@@ -1,0 +1,26 @@
+-module(pometo_test_helper).
+
+-export([run/2]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+run(Code, Expected) when is_list(Code) andalso is_list(Expected) ->
+    Got = try
+        Tokens               = pometo_lexer:get_tokens(Code),
+        Parsed               = parse(Tokens),
+        {Results, _Bindings} = pometo_runtime:run_ast(Parsed),
+        pometo_runtime:format(Results)
+    catch Type:Error -> ?debugFmt("Test failed to run ~p:~p", [Type, Error]),
+                        {error, "test failed to run"}
+    end,
+    ?_assertEqual(Expected, Got).
+
+parse(Tokenlist) ->
+    Parsed = pometo_parser:parse(Tokenlist),
+    case Parsed of
+        {ok,    Parse} -> Parse;
+        {error, Error} -> ?debugFmt("Parser error ~p~n", [Error]),
+                          "error"
+    end.
+
+

--- a/test/parser_tests.erl
+++ b/test/parser_tests.erl
@@ -10,15 +10,19 @@ basic_dyadic_plus_test_() ->
 	Str = "1.1 2.2 + 3.3 4.4",
 	Tokens = pometo_lexer:get_tokens(Str),
 	{ok, Got} = pometo_parser:parse(Tokens),
-	Exp = {expr, scalar, Str, dyadic, "+",
-    	                   [{'¯¯⍴¯¯', eager, false, float, [2], [1.1, 2.2]},
-        	                {'¯¯⍴¯¯', eager, false, float, [2], [3.3, 4.4]}]},
+	Exp = {{liffey, {dyadic, "+"},
+	                [
+                     {liffey, {'¯¯⍴¯¯', eager, false, [2]}, [1.1, 2.2]},
+                     {liffey, {'¯¯⍴¯¯', eager, false, [2]}, [3.3, 4.4]}
+                    ]}, []},
 	?_assertEqual(Exp, Got).
 
 basic_monadic_plus_test_() ->
 	Str = "+ 3.3 4.4",
 	Tokens = pometo_lexer:get_tokens(Str),
 	{ok, Got} = pometo_parser:parse(Tokens),
-	Exp = {expr, scalar, Str, monadic, "+",
-    	                   [{'¯¯⍴¯¯', eager, false, float, [2], [3.3, 4.4]}]},
+	Exp = {{liffey, {monadic, "+"},
+	                [
+                     {liffey, {'¯¯⍴¯¯', eager, false, [2]}, [3.3, 4.4]}
+                    ]}, []},
 	?_assertEqual(Exp, Got).


### PR DESCRIPTION
Rewrite of:

* the parser
* the runtime
* the internal record formats of the toolchain

This is to make the internal structure more Lispy as per the design noted of 2020/05/19

Liffey has a soft definition of being an Erlang data structure with a 1-2-1 correspondence to LFE (Lisp Flavoured Erlang)