### PR TITLE
Rewrite of internals to make the AST a realer Lisp

### DIFF
--- a/docs/design_docs.md
+++ b/docs/design_docs.md
@@ -315,7 +315,7 @@ Top level record:
 ```
 -record(ast, {
           op,     [dyadic_+, monadic_+, dyadic_-, monadic_-, ←       etc, etc],
-          op_str, [" + ",    " + ",     " - ",    " _" ,     "  ←  " etc, etc],
+etc, etc],
           args,   []
     }).
 ```

--- a/src/parser_include.hrl
+++ b/src/parser_include.hrl
@@ -17,11 +17,17 @@ handle_value(Sign, {_, _, _, _, Val}) ->
   #liffey{op = Rho, args = [SignedVal]}.
 
 extract(monadic, {scalar_fn, _, _, _, Fnname}, Args) ->
-  {#liffey{op = {monadic, Fnname}, args = Args}, []};
+  {#liffey{op = {monadic, Fnname}, args = Args}, #{}};
 extract(dyadic, {scalar_fn, _, _, _, Fnname}, Args) ->
-  {#liffey{op = {dyadic, Fnname}, args = Args}, []}.
+  {#liffey{op = {dyadic, Fnname}, args = Args}, #{}}.
 
-make_let({var, _, _, _, Var}, Liffey) ->
-  {Liffey, [#var{name = Var, expr = Liffey}]}.
+make_let({var, _, _, _, Var}, #liffey{} = Expr, Bindings) ->
+  {Expr, bind(Var, Expr, Bindings)}.
 
 format(X) -> lists:flatten(io_lib:format("~p", [X])).
+
+bind(Var, Expr, Bindings) ->
+  case maps:is_key(Var, Bindings) of
+    true  -> throw("binding should be immutable");
+    false -> maps:put(Var, Expr, Bindings)
+  end.

--- a/src/parser_records.hrl
+++ b/src/parser_records.hrl
@@ -13,8 +13,7 @@
 
 % leaf records
 -record(var, {
-              name,
-              expr
+              name
              }).
 
 % complex number record TBD

--- a/src/pometo_parser.yrl
+++ b/src/pometo_parser.yrl
@@ -26,7 +26,7 @@ Expression -> Let                     : '$1'.
 Expression -> Vector scalar_fn Vector : extract(dyadic, '$2', ['$1', '$3']).
 Expression -> scalar_fn Vector        : extract(monadic, '$1', ['$2']).
 
-Let -> var let_op Vector : make_let('$1', '$3').
+Let -> var let_op Vector : make_let('$1', '$3', #{}).
 
 Vector -> Vector Scalar : append('$1', '$2').
 Vector -> Scalar        : '$1'.


### PR DESCRIPTION
These changes are in line with the Design Doc working notes of 2020/05/19

They have also been carried through to Rappel which now handles the happy paths for all supported Pometo constructs as well as adding external data bindings.

Unhappy paths (errors, miscompilations) are not properly supported either in this repo or Rappel (yet)